### PR TITLE
List authors all on one line, rather than have a looooong list of authors in the book

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -1,21 +1,6 @@
 --- 
 title: "Merely Useful"
-author:
-  - "Dhavide Aruliah"
-  - "Madeleine Bonsma-Fisher"
-  - "Jonathan Dursi"
-  - "Auriel Fournier"
-  - "Kate Hertweck"
-  - "Katy Huff"
-  - "Damien Irving"
-  - "Luke Johnston"
-  - "Christina Koch"
-  - "Brandeis Marshall"
-  - "Joel Ostblom"
-  - "Matt Turk"
-  - "Elizabeth Wickes"
-  - "Charlotte Wickham"
-  - "Greg Wilson"
+author: "Dhavide Aruliah, Madeleine Bonsma-Fisher, Jonathan Dursi, Auriel Fournier, Kate Hertweck, Katy Huff, Damien Irving, Luke Johnston, Christina Koch, Brandeis Marshall, Joel Ostblom, Matt Turk, Elizabeth Wickes, Charlotte Wickham, Greg Wilson"
 date: "`r Sys.Date()`"
 site: bookdown::bookdown_site
 documentclass: book


### PR DESCRIPTION
Authors are presented as a long list, each taking a paragraph. This PR puts authors as a comma separated, single line presentation.

Resolves #39.