### PR TITLE
Detail in README about protected branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ We'll be working off of the `book` branch, **not the `master` branch**. The
 `book` branch is a "protected" branch, meaning it has a couple of conditions
 (which can always be updated if needed):
 
-1. Only @gvwilson and @lwjohnst86 can push directly to the main repo's `book` branch.
+1. Only @gvwilson and @lwjohnst86 can push directly to the main repo's `book` branch and only they can merge a PR (others will be added later).
 2. Everyone else must submit a PR either from their forked `book` branch or from another branch.
 3. Each PR must pass the Travis CI check and must get at least one (1) approval from someone else in order to be merged in.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,15 @@ Or via RStudio:
 
 ## Workflow
 
-If you are doing a major overhaul on material:
+We'll be working off of the `book` branch, **not the `master` branch**. The
+`book` branch is a "protected" branch, meaning it has a couple of conditions
+(which can always be updated if needed):
+
+1. Only @gvwilson and @lwjohnst86 can push directly to the main repo's `book` branch.
+2. Everyone else must submit a PR either from their forked `book` branch or from another branch.
+3. Each PR must pass the Travis CI check and must get at least one (1) approval from someone else in order to be merged in.
+
+With that, the next things to consider are that if you are doing a major overhaul on material:
 
 1.  Pick a chapter.
 2.  Check that there isn't an outstanding branch with its name (i.e., that no one else is also doing a major overhaul).
@@ -78,7 +86,7 @@ If you are doing a major overhaul on material:
 4.  Make some trivial change and create a PR with the subject line `revisions to automate` (or whatever the chapter name is).
 5.  Add the label "work in progress" to that PR.
 6.  When it's ready for review, remove the label and post a note in Slack asking for a reviewer.
-7.  When the material is ready for publication, merge it into the `book` branch.
+7.  When the material is ready for publication, merge it into the `book` branch (under the conditions as stated above).
 
 If you are making a smaller change, please create a branch with a meaningful name, submit changes, and ask for a reviewer.
 Please do not assign PRs to people without first checking with them.


### PR DESCRIPTION
Since the master branch gets updated by travis, and since the source material could be modified easily by others (sometimes a good thing), I've set the book branch to be protected. I've also added a few other conditions to give some "rigor" to each PR or change. This PR adds that detail to the README.