### PR TITLE
Add data to website

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,16 +37,16 @@ RSE_FILES=\
   backlog.Rmd \
   style.Rmd \
   process.Rmd \
-  rse-ci.Rmd \
   remote.Rmd \
   tools.Rmd \
   docs.Rmd \
   refactor.Rmd \
   project.Rmd \
   inclusive.Rmd \
+  rse-ci.Rmd \
   rse-r-package.Rmd \
   rse-r-testing.Rmd \
-  py-package.Rmd \
+  rse-py-package.Rmd \
   rse-publish.Rmd \
   teamwork.Rmd \
   pacing.Rmd \

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,9 @@ everything : ${ALL_HTML} ${ALL_PDF} ${INDEX_HTML}
 ${INDEX_HTML} : ./_index.html
 	cp ./_index.html ${INDEX_HTML}
 	cp -r ./static _book/static
+	mkdir _book/data
+	find dir1 -maxdepth 1 -type f -exec cp -t dir2 {} +
+	cp ./data _book/data
 
 #-------------------------------------------------------------------------------
 

--- a/rse-py-package.Rmd
+++ b/rse-py-package.Rmd
@@ -821,7 +821,7 @@ Success!
 
 FIXME:  need some clever exercises here
 
-## How can I distribute command-line scripts in my Python package? {#rse-py-package-install}
+## How can I distribute command-line scripts in my Python package? {#rse-py-package-distrib-scripts}
 
 Our package now works and can be installed in Python environments.
 


### PR DESCRIPTION
Resolves #179.

Everyone can now add access the data via `read_csv("https://merely-useful.github.io/data/site.csv")`. Or whichever csv file you want.