### PR TITLE
RSE: Project/team management

### DIFF
--- a/rse-proj-manage.Rmd
+++ b/rse-proj-manage.Rmd
@@ -2,13 +2,39 @@
 
 ## Questions
 
-## How can we keep track of who's doing what and what's still to be done?
+How can we keep track of current tasks?
+How can we figure out what to build next?
+
+## Tracking tasks
   - issue tracking
   - issue tagging as lightweight workflow
 
-## How can we figure out what to build next?
-  - planning vs. agile
-  - 3x3 prioritization
+## Planning and prioritizing 
+  - models: planning vs. agile, 3x3 prioritization
+  - tools: roadmaps and milestones (a la GitHub, [Open Canvas](https://mozilla.github.io/open-leadership-training-series/articles/opening-your-project/develop-an-open-project-strategy-with-open-canvas/)
+
+# Team management
+
+## Questions
+
+How do we encourage participation of a diverse group?
+How do we make collaborative decisions?
+How do we manage interpersonal conflict?
+
+## Including everyone
+  - allyship: who is your team?
+  - readme and contributing guidelines
+  - licensing
+
+## Collaborative decision making
+  - how to run a meeting
+  - project governance
+
+## Managing interpersonal conflict
+  - potential types of conflict:
+  - sources of conflict
+  - strategies for handling difficult project members
+
 
   ---
   title: "Managing Backlog"
@@ -33,7 +59,7 @@
   they can be used to manage any kind of work
   and are often a convenient way to manage discussions as well.
 
-  ## How can I manage the work I still have to do? {#s:backlog-issues}
+## How can I manage the work I still have to do? {#s:backlog-issues}
 
   Like other [forges](#g:forge),
   GitHub records a set of issues for each project,
@@ -87,7 +113,7 @@
       or to rely on search to find things,
       since using issues this way requires someone to put in curation time.)
 
-  ## How can I write a good bug report? {#s:backlog-bugs}
+## How can I write a good bug report? {#s:backlog-bugs}
 
   The better the bug report,
   the faster the response,
@@ -141,7 +167,7 @@
   ```
   {: title="backlog/bug_report.txt"}
 
-  ## How can I use labels to organize work? {#s:backlog-label}
+## How can I use labels to organize work? {#s:backlog-label}
 
   There is always more work to do than there is time to do it.
   Issue trackers let project members add [labels](#g:issue-label) to issues to manage this.
@@ -166,7 +192,7 @@
       If you help potential new contributors find places to start,
       they're more likely to do so [Stei2014](#BIB).
 
-  ## How can I use labels to prioritize work? {#s:backlog-triage}
+## How can I use labels to prioritize work? {#s:backlog-triage}
 
   The labels listed above described what kind of work an issue describes;
   a separate set of labels can be used to indicate how important that work is.
@@ -206,7 +232,7 @@
   After a while,
   a project that uses labels for specific events can have a *lot* of old labels...
 
-  ## How can I use issues to enforce a workflow for a project? {#s:backlog-workflow}
+## How can I use issues to enforce a workflow for a project? {#s:backlog-workflow}
 
   If you're using GitHub,
   the short answer to this section's title question is,
@@ -237,10 +263,6 @@
 
 
 ## How can we make decisions?
-- how to run a meeting
-- project governance
-- strategies for handling difficult project members
-
 
 ### How can we run meetings more efficiently? {#s:teamwork-efficient}
 
@@ -1018,10 +1040,6 @@ Like any written rules,
 a Code of Conduct requires constant interpretation;
 like everything else,
 discussion about specific cases becomes easier with practice.
-
-## Summary {#s:inclusive-summary}
-
-FIXME: create concept map for making an inclusive project
 
 ## Exercises {#s:inclusive-exercises}
 

--- a/rse-proj-manage.Rmd
+++ b/rse-proj-manage.Rmd
@@ -1,0 +1,1030 @@
+# Project management
+
+## Questions
+
+## How can we keep track of who's doing what and what's still to be done?
+  - issue tracking
+  - issue tagging as lightweight workflow
+
+## How can we figure out what to build next?
+  - planning vs. agile
+  - 3x3 prioritization
+
+  ---
+  title: "Managing Backlog"
+  questions:
+  -   "How can I tell what needs to be done and who is doing it?"
+  objectives:
+  -   "Explain what an issue tracking tool does and what it should be used for."
+  -   "Explain how to use labels on issues to manage work."
+  -   "Describe the information a well-written issue should contain."
+  keypoints:
+  -   "Create issues for bugs, enhancement requests, and discussions."
+  -   "Add people to issues to show who is responsible for working on what."
+  -   "Add labels to issues to identify their purpose."
+  -   "Use rules for issue state transitions to define a workflow for a project."
+  ---
+
+  Version control tells us where we've been;
+  [issues](#g:issue) tells us where we're going.
+  Issue tracking tools are often called ticketing systems or bug trackers
+  because they were created to keep track of work that needs to be done and bugs that needed fixing.
+  However,
+  they can be used to manage any kind of work
+  and are often a convenient way to manage discussions as well.
+
+  ## How can I manage the work I still have to do? {#s:backlog-issues}
+
+  Like other [forges](#g:forge),
+  GitHub records a set of issues for each project,
+  and allows members of that project to create new ones,
+  modify existing ones,
+  and search both.
+  Every issue has:
+
+  -   A unique ID, such as `#123`, which is also part of its link.
+      This makes issues easy to find and refer to:
+      in particular, GitHub automatically translates the expression `#123` in a [commit message](#g:commit-message)
+      into a link to that issue.
+
+  -   A one-line title to aid browsing and search.
+
+  -   The issue's current status.
+      In simple systems (like GitHub's),
+      each issue is either open or closed,
+      and by default,
+      only open issues are displayed.
+
+  -   The ID of the issue's creator.
+      The IDs of people who have commented on it or modified it are also embedded in the issue's history,
+      which helps when using issues to manage discussions.
+
+  -   A full description that may include screenshots, error messages, and just about anything else.
+
+  -   Replies, counter-replies, and so on from people with an interest in the issue.
+
+  Broadly speaking,
+  people create three kinds of issues:
+
+  1.  *Bug reports* to describe problems they have encountered.
+      A good bug report is a work of art,
+      so we discuss them in detail [below](#s:backlog-bugs).
+
+  2.  *Feature requests* (for software packages)
+      or *tasks* (for projects).
+      These issues are the other kind of [work backlog](#g:backlog) in a project:
+      not "what needs to be fixed" but "what do we want to do next".
+
+  3.  *Questions*.
+      Many projects encourage people to ask questions on a mailing list or in a chat channel,
+      but answers given there can be hard to find later,
+      which leads to the same questions coming up over and over again.
+      If people can be persuaded to ask questions by filing issues,
+      and to respond to issues of this kind,
+      then the project's old issues become a customized [Stack Overflow][stack-overflow] for the project.
+      (In practice,
+      most projects find that it's easier to create a page of links to old questions and answers,
+      or to rely on search to find things,
+      since using issues this way requires someone to put in curation time.)
+
+  ## How can I write a good bug report? {#s:backlog-bugs}
+
+  The better the bug report,
+  the faster the response,
+  and the more likely the response will actually address the issue [Bett2008](#BIB).
+
+  1.  Make sure the problem actually *is* a bug.
+      It's always possible that you have called a function the wrong way
+      or done an analysis using the wrong configuration file;
+      if you take a minute to double-check,
+      you could well fix the problem yourself.
+  2.  Try to come up with a [reproducible example](#g:reprex), or reprex.
+      A reprex includes only the steps or lines of code needed to make the problem happen;
+      again, you'll be surprised how often you can solve the problem yourself
+      as you trim down your steps to create one.
+  3.  Write a one-line title for the issue
+      and a longer (but still brief) description that includes relevant details).
+  4.  Attach any screenshots that show the problem or (slimmed-down) input files needed to re-create it.
+  5.  Describe the version of the software you were using,
+      the operating system you were running on,
+      and anything else that might affect behavior.
+  6.  Describe each problem separately so that each one can be tackled on its own.
+      (This parallels the rule about creating a branch in version control for each bug fix or feature
+      discussed in [s:branches](#REF).)
+
+  Here's an example of a well-written bug report with all of the fields mentioned above:
+
+  ```text
+  ID: 1278
+  Creator: standage
+  Owner: malvika
+  Labels: Bug, Assigned
+  Summary: wordbase.py fails on accented characters
+  Description:
+
+  1.  Create a text file called 'accent.txt' containing the word "Pumpernickel"
+      with an umlaut over the 'u'.
+
+  2.  Run 'python wordbase.py --all --message accent.txt'
+
+  Program should print "Pumpernickel" on a line by itself with the umlaut, but
+  instead it fails with the message:
+
+      No encoding for [] on line 1 of 'accent.txt'.
+
+  ([] shows where a solid black box appears in the output instead of a
+  printable character.)
+
+  Versions:
+  -   `python wordbase.py --version` reports 0.13.1
+  -   Using on Windows 10.
+  ```
+  {: title="backlog/bug_report.txt"}
+
+  ## How can I use labels to organize work? {#s:backlog-label}
+
+  There is always more work to do than there is time to do it.
+  Issue trackers let project members add [labels](#g:issue-label) to issues to manage this.
+  A label is just a word or two;
+  GitHub allows project owners to create any labels they want
+  that users can then add to their issues.
+  A small project should always use these four labels:
+
+  -   *Bug*: something should work but doesn't.
+  -   *Enhancement*: something that someone wants added.
+  -   *Task*: something needs to be done, but won't show up in code
+      (e.g., organizing the next team meeting).
+  -   *Discussion*: something the team needs to make a decision about.
+      (All issues can have discussion---this category is for issues that start that way.)
+
+  <!-- == noindent -->
+  It might also use:
+
+  -   *Question*: how is something supposed to work (discussed [earlier](#s:backlog-issues)).
+  -   *Suitable for Newcomer* or *Beginner-Friendly*:
+      to identify an easy starting point for someone who has just joined the project.
+      If you help potential new contributors find places to start,
+      they're more likely to do so [Stei2014](#BIB).
+
+  ## How can I use labels to prioritize work? {#s:backlog-triage}
+
+  The labels listed above described what kind of work an issue describes;
+  a separate set of labels can be used to indicate how important that work is.
+  These labels typically have names like "High Priority" or "Low Priority";
+  their purpose is to help [triage](#g:triage),
+  which is the process of deciding what is going to be worked on in what order.
+
+  In a large project,
+  this is the responsibility of the product manager ([s:process](#REF));
+  in a small one,
+  it's common for the project's lead to decide this,
+  or for project members to use up-votes and down-votes on an issue
+  to indicate how important they think it is.
+
+  However the decision is made,
+  it's helpful to use six more labels to record the outcomes:
+
+  -   *Urgent*: this needs to be done *now*
+      (typically reserved for security fixes).
+  -   *Current*: this issue is included in the current round of work.
+  -   *Next*: this issue is (probably) going to be included in the next round.
+  -   *Eventually*: someone has looked at the issue and believes it needs to be tackled,
+      but there's no immediate plan to do it.
+  -   *Won't Fix*: someone has decided that the issue isn't going to be addressed,
+      either because it's out of scope or because it's not actually a bug.
+      Once an issue is marked this way,
+      it is usually then closed.
+  -   *Duplicate*: this issue is a duplicate of one that's already in the system.
+      Again,
+      issues marked this way are usually then closed.
+
+  Larger projects will replaced "Current", "Next", and "Eventually"
+  with labels corresponding to upcoming software releases, journal issues, or conferences.
+  Unfortunately,
+  this doesn't work well on GitHub's issue tracking system,
+  since there's no way to "retire" a label without deleting it.
+  After a while,
+  a project that uses labels for specific events can have a *lot* of old labels...
+
+  ## How can I use issues to enforce a workflow for a project? {#s:backlog-workflow}
+
+  If you're using GitHub,
+  the short answer to this section's title question is,
+  "You can't,"
+  but you can create conventions,
+  and more sophisticated issue tracking systems will let you enforce those conventions.
+  The basic idea is to only allow issues to move from some states to others,
+  and to only allow some people to move them.
+  For example,
+  [f:backlog-lifecycle](#FIG) shows a workflow for handling bugs in a medium-sized project:
+
+  {% include figure.html id="f:backlog-lifecycle" src="lifecycle.svg" caption="Issue State Transitions" %}
+
+  -   An "Open" issue becomes "Assigned" when someone is made responsible for it.
+  -   An "Assigned" issue becomes "Active" when that person starts to work on it.
+  -   If they stop work for any length of time, it becomes "Suspended".
+      (That way, people who are waiting for it know not to hold their breath.)
+  -   An "Active" bug can either be "Fixed" or "Cancelled",
+      where the latter state means that the person working on it has decided it's not really a bug.
+  -   Once a bug is "Fixed",
+      it can either be "Closed" or, if the fix doesn't work properly,
+      moved back into the "Open" state and go around again.
+
+  Workflows like this are more complex than small projects need,
+  but as soon as the team is distributed---particularly distributed across timezones---it's
+  very helpful to be able to find out what's going on
+  without having to wait for someone to be awake.
+
+
+## How can we make decisions?
+- how to run a meeting
+- project governance
+- strategies for handling difficult project members
+
+
+### How can we run meetings more efficiently? {#s:teamwork-efficient}
+
+Most people do meetings poorly:
+they don't have an agenda going in,
+they don't take minutes,
+they waffle on or wander off into irrelevancies,
+they repeat what others have said or recite banalities simply so that they'll have said something,
+and they hold side conversations
+(which pretty much guarantees that the meeting will be a waste of time).
+Knowing how to run a meeting efficiently is a core skill for anyone who wants to get things done.
+Knowing how to take part in someone else's meeting is just as important,
+but gets far less attention:
+everyone offers leadership training,
+nobody offers followership training.
+
+The rules for running meetings quickly and smoothly are well known but rarely followed:
+
+Decide if there actually needs to be a meeting.
+:   If the only purpose is to share information,
+    have everyone send a brief email instead.
+    Remember, people can read faster than they can speak:
+    if someone has facts for the rest of the team to absorb,
+    the most polite way to communicate them is to type them in.
+
+Write an agenda.
+:   If nobody cares enough about the meeting to prepare a point-form list of what's to be discussed,
+    the meeting itself probably doesn't need to happen.
+
+Include timings in the agenda.
+:   Timings help you prevent early items stealing time from later ones.
+    Your first estimates with any new group will be wildly optimistic,
+    so revise them upward for subsequent meetings.
+    However,
+    you shouldn't plan a second or third meeting just because the first one ran over-time:
+    instead, try to figure out why you're running over and fix the underlying problem.
+
+Prioritize.
+:   Tackle issues that will have high impact but take little time first,
+    and things that will take more time but have less impact later.
+    That way, if the first things run over time,
+    the meeting will still have accomplished something.
+
+Make one person responsible for keeping things moving.
+:   One person should be made chair,
+    and be responsible for keeping items to time,
+    chiding people who are having side conversations or checking email,
+    and asking people who are talking too much to get to the point.
+    The chair should *not* do all the talking;
+    in fact,
+    whoever is in charge will talk less in a well-run meeting than most other participants.
+
+Require politeness.
+:   No one gets to be rude,
+    no one gets to ramble,
+    and if someone goes off topic,
+    it's the chair's job to say,
+    "Let's discuss that elsewhere."
+
+No interruptions.
+:   Participants should raise a finger,
+    put up a sticky note,
+    or make one of the other gestures people use at high-priced auctions
+    when they want to speak.
+    The chair should keep track of who wants to speak and give them time in turn.
+
+No side conversations.
+:   This makes meetings more efficient because
+    Nobody can actually pay attention to two things at once.
+    If distractions are tolerated,
+    people will miss things or they'll have to be repeated.
+    More importantly,
+    not paying attention is insulting---chatting with a friend
+    while someone explains what they did last week is a really effective way to say,
+    "I don't think you or your work is important."
+
+No technology.
+:   Insist that everyone put their phones, tablets, and laptops into politeness mode
+    (i.e., close them).
+    If this is too stressful,
+    let participants hang on to their electronic pacifiers but turn off the network
+    so that they really *are* using them just to take notes or check the agenda.
+    The one exception is accessibility needs:
+    if someone needs their phone, their laptop, or some other aid
+    in order to take part in the meeting,
+    nobody has a right to tell them "no".
+
+Take minutes.
+:   Someone other than the chair should take point-form notes
+    about the most important information that was shared,
+    and about every decision that was made or every task that was assigned to someone.
+
+Take notes.
+:   While other people are talking,
+    participants should take notes of questions they want to ask
+    or points they want to make.
+    (You'll be surprised how smart it makes you look when it's your turn to speak.)
+
+End early.
+:   If your meeting is scheduled for 10:00-11:00,
+    aim to end at 10:55 to give people time to get where they need to go next.
+
+## What should we do when the meeting is over? {#s:teamwork-after}
+
+As soon as the meeting is over, circulate the minutes
+(i.e., emailed them to everyone or post them to a wiki):
+
+People who weren't at the meeting can keep track of what's going on.
+:   You and your teammates all have to juggle tasks from other projects or courses,
+    which means that sometimes you won't be able to make it to meetings.
+    A wiki page,
+    email message,
+    or blog entry is a much more efficient way to catch up than asking a team mate,
+    "Hey, what did I miss?"
+
+Everyone can check what was actually said or promised.
+:   More than once,
+    one of us has looked over the minutes of a meeting and thought,
+    "Did I say that?" or,
+    "Wait a minute, I didn't promise to have it ready then!"
+    Accidentally or not,
+    people will often remember things differently;
+    writing it down gives the team a chance to correct mis-recollection,
+    mis-interpretation,
+    or mis-representation,
+    which can save a lot of anguish later on.
+
+People can be held accountable at subsequent meetings.
+:   There's no point making lists of questions and action items
+    if you don't follow up on them later.
+    If you're using a ticketing system ([s:backlog](#REF)),
+    create a ticket for each new question or task right after the meeting
+    and update those that are being carried forward.
+    That way,
+    your agenda for the next meeting can start by rattling through
+    the list of open tickets.
+
+Run all your meetings like this for a month,
+with the goal of making each one a minute shorter than the one before,
+and we promise that you'll build better software.
+
+## How can we keep people from talking too much or too little? {#s:teamwork-fair}
+
+Some people are so used to the sound of their own voice that
+they will talk half the time no matter how many other people are in the room.
+One way to combat this is to give everyone three sticky notes at the start of the meeting.
+Every time they speak,
+they have to give up one sticky note.
+When they're out of stickies,
+they aren't allowed to speak until everyone has used at least one,
+at which point everyone gets all of their sticky notes back.
+This ensures that nobody talks more than three times as often as
+the quietest person in the meeting,
+which completely changes group dynamics:
+people who have given up trying to be heard because they always get trampled
+suddenly have space to contribute,
+and the overly-frequent speakers quickly realize just how unfair they have been.
+
+Another useful technique is called interruption bingo.
+Draw a grid and label the rows and columns with the participants' names.
+Each time one person interrupts another,
+add a tally mark to the appropriate cell;
+halfway through the meeting,
+take a moment to look at the results.
+In most cases,
+you will see that one or two people are doing all of the interrupting,
+often without being aware of it.
+After that, saying, "All right, I'm adding another tally to the bingo card,"
+is often enough to get them to throttle back.
+(Note that this technique is for managing interruptions,
+not speaking time.
+It may be completely appropriate for people with more knowledge of a subject
+to speak about it more often in a meeting,
+but it is never appropriate to repeatedly cut people off.)
+
+## How should we run online meetings? {#s:teamwork-online}
+
+Chelsea Troy's discussion of
+[why online meetings are often frustrating and unproductive][troy-meetings]
+makes an important point:
+in most online meetings,
+the first person to speak during a pause gets the floor.
+As a result,
+"If you have something you want to say,
+you have to stop listening to the person currently speaking
+and instead focus on when they're gonna pause or finish
+so you can leap into that nanosecond of silence and be the first to utter something.
+The format...encourages participants who want to contribute
+to say more and listen less."
+
+The solution is to run a text chat beside the video conference
+where people can signal that they want to speak.
+The chair can then select people from the waiting list.
+This practice can be reinforced by having everyone mute themselves,
+and only allowing the moderator to unmute people.
+
+## What sort of people make teamwork hard? {#s:teamwork-people}
+
+FIXME: introduction (without Tolstoy)
+
+Anna
+:   knows more about every subject than everyone else on the team put together---at least,
+    she thinks she does.
+    No matter what you say, she'll correct you;
+    no matter what you know, she knows better.
+    Anna is pretty easy to spot:
+    if you keep track of how often people interrupt one another in team meetings,
+    her score is usually higher than everyone else's put together.
+
+Bao
+:   is a contrarian:
+    no matter what anyone says, he'll take the opposite side.
+    This can be healthy in small doses,
+    but if someone plays devil's advocate at every turn,
+    they're just impeding progress.
+
+Caitlin
+:   has so little confidence in her own ability
+    (despite her good grades)
+    that she won't make any decision,
+    no matter how small,
+    until she has checked with someone else.
+    Everything has to be spelled out in detail for her
+    so that there's no possibility of her getting anything wrong.
+
+Frank
+:   believes that knowledge is power.
+    He enjoys knowing things that other people don't---or to be more accurate,
+    he enjoys it when people know he knows things they don't.
+    Frank is good at making things work,
+    but when asked how he did it,
+    he'll grin and say, "Oh, I'm sure you can figure it out."
+
+Gary
+:   is a hitchhiker.
+    He has discovered that most people would rather shoulder some extra work than snitch,
+    and he takes advantage of it at every turn.
+    The frustrating thing is that he's so damn *plausible*
+    when someone finally does confront him.
+    "There have been mistakes on all sides," he says,
+    or, "Well, I think you're nit-picking."
+    The only way to deal with Kenny is to stand up to him:
+    remember, if he's not doing his share,
+    *he's the bad guy*, not you.
+
+Hediyeh
+:   is quiet---very quiet.
+    She never speaks up in meetings,
+    even when she knows that what other people are saying is wrong.
+    She might contribute to the mailing list,
+    but she's very sensitive to criticism,
+    and will always back down rather than defending her point of view.
+    Hediyeh isn't a troublemaker,
+    but rather a lost opportunity.
+
+Melissa
+:   would easily have made the varsity procrastination team
+    if she'd bothered to show up to tryouts.
+    She means well,
+    and she really does feel bad about letting people down,
+    but somehow something always comes up,
+    and her tasks are never finished until the last possible moment.
+    Of course,
+    that means that everyone who is depending on her
+    can't do their work until *after* the last possible moment...
+
+Petra
+:   has a favorite phrase: "why don't we".
+    Why don't we write a GUI to help people edit the program's configuration files?
+    Hey, why don't we invent our own little language for designing GUIs?
+    Her energy and enthusiasm are hard to argue with,
+    but argue you must.
+    Otherwise,
+    for every step you move forward,
+    the project's goalposts will recede by two.
+    This is called [feature creep](#g:feature-creep),
+    and has ruined many projects that might otherwise have delivered something small but useful.
+
+Raj
+:   is rude.
+    "That's stupid," and a mixed bag of obscenities are his favorite phrases.
+    "It's just the way I talk," he says,
+    not knowing or not caring that for a lot of people,
+    that kind of language has often been a prelude to bullying or worse.
+    His only redeeming grace is that he can't dissemble as well as Gary,
+    so he's easier to get rid of.
+
+Sergei
+:   is simply incompetent.
+    He doesn't understand the problem,
+    he hasn't bothered to master the tools and libraries he's supposed to be using,
+    the code he checks in doesn't run,
+    and his thirty-second bug fixes introduce more problems than they solve.
+    If he means well,
+    try to re-partition the work so that he'll do less damage.
+    If he doesn't,
+    he should be treated like any other hitchhiker.
+
+## How should we handle conflict within the team? {#s:teamwork-conflict}
+
+FIXME: this is not about harassment or abuse---see [s:inclusive](#REF) for that.
+
+You just missed an important deadline,
+and people are unhappy.
+The sick feeling in the pit of your stomach has turned to anger:
+you did *your* part,
+but Marta didn't finish her stuff until the very last minute,
+which meant that no one else had time to spot the two big mistakes she'd made.
+As for Chul, well, he didn't deliver at all---again.
+If something doesn't change,
+this project is going to pull down your performance review so far
+that you might have to start looking for a new job.
+
+Situations like this come up all the time.
+Broadly speaking, there are four ways you can deal with them:
+
+1.  Cross your fingers and hope that things will get better on their own,
+    even though the last three times you hoped they would,
+    they didn't.
+
+2.  Do extra to make up for others' shortcomings.
+    This sometimes works in the short term,
+    and saves you the mental anguish of confronting others,
+    but the time for that "extra" has to come from somewhere;
+    what usually ends up happening is that other parts of the project,
+    or your personal life,
+    suffer.
+
+3.  Lose your temper and start shouting.
+    Unfortunately,
+    people often wind up displacing their anger into other parts of their life:
+    I've seen developers yell at waitresses for bringing incorrect change
+    when what they really needed to do was tell their boss,
+    "No, I *won't* work through another holiday weekend
+    to make up for your decision to short-staff the project."
+
+4.  Take constructive steps to fix the underlying problem.
+
+Most of us find number four hard because we don't like confrontation.
+If you manage it properly,
+though,
+it is a lot less bruising,
+which means that you don't have to be as afraid of initiating it.
+Also,
+if people believe that you will actually take steps
+when they bully, lie, procrastinate, or do a half-assed job,
+they will usually avoid making it necessary.
+(A colleague once said that
+she had never met anyone who wished they had waited longer
+before putting their foot down.)
+
+Here are the steps you should take when you feel that
+a teammate isn't pulling their weight:
+
+Make sure you're not guilty of the same sin.
+:   You won't get very far complaining about someone else interrupting in meetings
+    if you do it just as frequently.
+
+Check expectations.
+:   Are you sure the offender knows what standards they are supposed to be meeting?
+    This is where things like job descriptions
+    or up-front discussion of who's responsible for what
+    come in handy.
+
+Check the situation.
+:   Is someone dealing with an ailing parent or immigration woes?
+    Have they been put to work on three other projects that you don't know about?
+
+Document the offense.
+:   Write down what the offender has actually done and why it's not good enough.
+    Doing this will help you clarify matters in your own mind.
+    It's also absolutely necessary if you have to escalate.
+
+Check with other team members.
+:   Are you alone in feeling that the offender is letting the team down?
+    If so, you aren't necessarily wrong,
+    but it'll be a lot easier to fix things if you have the support of the rest of the team.
+    Finding out who else on the team is unhappy can be the   hardest part of the whole process,
+    since you can't even ask the question without letting on that you're upset,
+    and word will almost certainly get back to whoever you're asking about,
+    who might then turn around and accuse you of stirring up trouble.
+    After a couple of unhappy experiences of this kind,
+    I've learned that it's best to raise the issue for the first time in a group of three:
+    you, the person you want to talk to,
+    and a third person who can act as unofficial moderator.
+
+Talk with the offender.
+:   This should be a team effort:
+    put it on the agenda at a team meeting,
+    present your complaint,
+    and make sure that the offender understands it.
+    In most cases this is enough:
+    human beings are herd animals,
+    and if someone realizes that they're going to be called on their hitchhiking or bad manners,
+    they will usually change their ways.
+
+Escalate as soon as there's a second offense.
+:   Hitchhikers and others who really don't have good intentions
+    are counting on you giving them one last chance after another
+    until the project is finished and they can go suck the life force out of their next victim.
+    *Don't fall into this trap.*
+    If someone stole your laptop, you'd report it right away.
+    If someone steals your time,
+    you're being pretty generous giving them more than one chance to mend their ways.
+
+In the context of a research project,
+"escalation" means "taking the issue to your supervisor".
+(If you're reluctant to do this because you don't want to be a snitch,
+go back and re-read the bit about people stealing your laptop.)
+Of course,
+your supervisor has probably had dozens of students complain to her over the years
+about teammates not doing their share---it isn't uncommon to have both halves of a pair
+tell the instructor that they're doing all the work.
+(This is yet another reason to use version control:
+it makes it easy to check who's actually written what.)
+In order to get her to take you seriously and help you fix your problem,
+you should send her an email, signed by several people describing the problem
+and the steps you have already taken to resolve it.
+Make sure the offender gets a copy as well,
+and ask your instructor to arrange a meeting to resolve the issue.
+
+This is where documentation is crucial.
+Hitchhikers are usually very good at appearing reasonable;
+they're very likely to nod as you present your case,
+then say, "Well, yes, but..." and rhyme off a bunch of minor exceptions
+or cases where others on the team have also fallen short of expectations.
+If you can't back up your complaint,
+your supervisor will likely be left with the impression that the whole team is dysfunctional,
+and nothing will improve.
+
+One technique your supervisor may ask you to use in a meeting like this
+is [active listening](#g:active-listening).
+As soon as one person makes a point,
+the person on the opposite side of the issue explains it back to them,
+as in, "So what I think Igor is saying is..."
+This guarantees that the second person has actually paid attention to what the first person said.
+It can also defuse a lot of tension,
+since explaining someone's position back to them
+forces you to see the world through their eyes,
+if only for a few moments.
+
+---
+title: "Including Everyone"
+questions:
+-   "Why should I make my project welcoming for everyone?"
+-   "Why do I need a license for my work?"
+-   "What license should I use for my work?"
+-   "How should I tell people what they can and cannot do with my work?"
+-   "Why should my project have an explicit Code of Conduct?"
+-   "How can I be a good ally?"
+objectives:
+-   "Explain the purpose of a Code of Conduct and the essential features an effective one must have."
+-   "Explain why adding licensing information to a repository is important."
+-   "Explain differences in licensing and social expectations."
+-   "Choose an appropriate license."
+-   "Explain where and how to communicate licensing."
+-   "Explain steps a project lead can take to be a good ally."
+keypoints:
+-   "Create an explicit Code of Conduct for your project modelled on the Contributor Covenant."
+-   "Be clear about how to report violations of the Code of Conduct and who will handle such reports."
+-   "People who are not lawyers should not try to write licenses."
+-   "Every project should include an explicit license to make clear who can do what with the material."
+-   "People who incorporate GPL'd software into their own software must make their software also open under the GPL license; most other open licenses do not require this."
+-   "The Creative Commons family of licenses allow people to mix and match requirements and restrictions on attribution, creation of derivative works, further sharing, and commercialization."
+-   "Be proactive about welcoming and nurturing community members."
+---
+
+The previous lesson talked about the physical organization of projects.
+This one talks about the social structure,
+which is more important to the project's success.
+A project can survive badly-organized code;
+none will survive for long if people are confused,
+pulling in different directions,
+or hostile.
+This lesson therefore talks about what projects can do to make newcomers feel welcome
+and to make things run smoothly after that.
+It draws on [Foge2005](#BIB),
+which describes how good open source software projects are run,
+and on [Boll2014](#BIB),
+which explains what a [commons](#g:commons) is and when it's the right model to use.
+
+## Why does a project need explicit rules? {#s:inclusive-rules}
+
+Jo Freeman's influential essay
+"[The Tyranny of Structurelessness][tyranny-structurelessness]" pointed out that
+every group has a power structure;
+the only question is whether it is formal and accountable
+or informal and unaccountable [Free1972](#BIB).
+Thirty-five years after the free software movement took on its modern, self-aware form,
+its successes and failures have shown that if a project doesn't clearly state
+who has the right to do what,
+it will wind up being run by whoever argues loudest and longest.
+
+## How should I license my software? {#s:inclusive-software-license}
+
+It might seem strange to put licensing under discussion of inclusivity,
+but if the law or a publication agreement prevents people from reading your work or using your software,
+you're excluding them
+(and probably hurting your own career).
+You may need to do this in order to respect personal or commercial confidentiality,
+but the first and most important rule of inclusivity
+is to be open by default.
+
+However,
+that is easier said than done,
+not least because the law hasn't kept up with everyday practice.
+[Mori2012](#BIB) and [this blog post][vanderplas-licensing] are good starting points from a scientist's point of view,
+while [Lind2008](#BIB) is a deeper dive for those who want details.
+In brief,
+creative works are automatically eligible for intellectual property (and thus copyright) protection.
+This means that every creative work has some sort of license:
+the only question is whether authors and users know what it is.
+
+Every project should therefore include an explicit license.
+This license should be chosen early:
+if you don't set it up right at the start,
+then each collaborator will hold copyright on their work
+and will need to be asked for approval when a license *is* chosen.
+By convention,
+the license is usually put in a file called `LICENSE` or `LICENSE.txt` in the project's root directory.
+This file should clearly state the license(s) under which the content is being made available;
+the plural is used because code, data, and text may be covered by different licenses.
+
+> *Don't write your own license*,
+> even if you are a lawyer:
+> legalese is a highly technical language,
+> and words don't mean what you think they do.
+
+To make license selection as easy as possible,
+GitHub allows you to select one of the most common licenses when creating a repository.
+The Open Source Initiative maintains [a list of licenses][osi-license-list],
+and [choosealicense.com][choose-license] will help you find a license that suits your needs.
+Some of the things you will need to think about are:
+
+1.  Do you want to license the code at all?
+2.  Is the content you are licensing source code?
+3.  Do you require people distributing derivative works to also distribute their code?
+4.  Do you want to address patent rights?
+5.  Is your license compatible with the licenses of the software you depend on?
+    For example, as we will discuss below,
+    you can use MIT-licensed code in a GPL-licensed project but not vice versa.
+
+The two most popular licenses for software are
+the [MIT license](#g:mit-license) and the [GNU Public License](#g:gpl) (GPL).
+The MIT license (and its close sibling the BSD license)
+say that people can do whatever they want to with the software as long as they cite the original source,
+and that the authors accept no responsibility if things go wrong.
+The GPL gives people similar rights,
+but requires them to share their own work on the same terms:
+
+> You may copy, distribute and modify the software as long as you track changes/dates in source files.
+> Any modifications to or software including (via compiler) GPL-licensed code must also be made available under the GPL
+> along with build & install instructions.
+>
+> --- [tl;dr][tldr-gpl]
+
+We recommend the MIT license:
+it places the fewest restrictions on future action,
+it can be made stricter later on,
+and the last thirty years shows that it's good enough to keep work open.
+
+## How should I license my data and reports? {#s:inclusive-software-text}
+
+The MIT license and the GPL apply to software.
+When it comes to data and reports,
+the most widely used family of licenses are those produced by [Creative Commons][creative-commons],
+which have been written and checked by lawyers and are well understood by the community.
+
+The most liberal license is referred to as [CC-0](#g:cc-0),
+where the "0" stands for "zero restrictions".
+CC-0 puts work in the public domain,
+i.e.,
+allows anyone who wants to use it to do so however they want with no restrictions.
+This is usually the best choice for data,
+since it simplifies aggregate analysis.
+For example,
+if you choose a license for data that requires people to cite their source,
+then anyone who uses that data in an analysis must cite you;
+so must anyone who cites *their* results,
+and so on,
+which quickly becomes unwieldy.
+
+The next most common license is the Creative Commons - Attribution license,
+usually referred to as [CC-BY](#g:cc-by).
+This allows people to do whatever they want to with the work
+as long as they cite the original source.
+This is the best license to use for manuscripts,
+since you *want* people to share them widely
+but also want to get credit for your work.
+
+Other Creative Commons licenses incorporate various restrictions on specific use cases:
+
+-   ND (no derivative works) prevents people from creating modified versions of your work.
+    Unfortunately, this also inhibits translation and reformatting.
+-   NC (no commercial use) does *not* mean that people cannot charge money for something that includes your work,
+    though some publishers still try to imply that in order to scare people away from open licensing.
+    Instead,
+    the NC clause means that people cannot charge for something that uses your work without your explicit permission,
+    which you can give under whatever terms you want.
+-   Finally,
+    SA (share-alike) requires people to share work that incorporates yours
+    on the same terms that you used.
+    Again,
+    this is fine in principle,
+    but in practice makes aggregation a headache.
+
+## Why should I establish a code of conduct for my project? {#s:inclusive-conduct}
+
+You don't expect to have a fire,
+but every large building or event should have a fire safety plan.
+Similarly,
+having a Code of Conduct for your project
+reduces the uncertainty that participants face about what is acceptable and unacceptable behavior.
+You might think this is obvious,
+but long experience shows that articulating it clearly and concisely reduces problems caused by have different expectations,
+particularly when people from very different cultural backgrounds are trying to collaborate.
+An explicit Code of Conduct is particularly helpful for newcomers,
+so having one can help your project grow
+and encourage people to give you feedback.
+
+Having a Code of Conduct is particularly important for people from marginalized or under-represented groups,
+who have probably experienced harassment or unwelcoming behavior before.
+By adopting one,
+you signal that your project is trying to be a better place than YouTube,
+Twitter,
+and other online cesspools.
+Some people may push back claiming that it's unnecessary,
+or that it infringes freedom of speech,
+but in our experience,
+what they often mean is that thinking about how they might have benefited from past inequity makes them feel uncomfortable,
+or that they like to argue for the sake of arguing.
+If having a Code of Conduct leads to them going elsewhere,
+that will probably make your project run more smoothly.
+
+Just as you shouldn't write your own license for a project,
+you probably shouldn't write your own Code of Conduct.
+We recommend using the [Contributor Covenant][covenant] for development projects
+and the [model code of conduct][model-coc] from the [Geek Feminism Wiki][geek-feminism] for in-person events.
+Both have been thought through carefully and revised in the light of experience,
+and both are now used widely enough that
+many potential participants in your project will not need to have them explained.
+
+Rules are meaningless if they aren't enforced.
+If you adopt a Code of Conduct,
+it is therefore important to be clear about how to report issues and who will handle them.
+[Auro2018](#BIB) is a short, practical guide to handling incidents;
+like the Contributor Covenant and the model code of conduct,
+it's better to start with something that other people have thought through and refined
+than to try to create something from scratch.
+
+## Why can I be a good ally for members of marginalized groups? {#s:inclusive-why-ally}
+
+Setting out rules and handling incidents when they arise is what projects can do;
+if you have power
+(even or especially the power that comes from being a member of the majority group),
+what you can do personally is be a good ally for members of marginalized groups.
+Much of this discussion is drawn from the [Frameshift Consulting Ally Skills workshop][ally-skills],
+which you should attend if you can.
+
+First,
+some definitions.
+[Privilege](#g:privilege) is an unearned advantage given to some people but not all;
+[oppression](#g:oppression) is systemic, pervasive inequality that benefits the privileged
+and harms those without privilege.
+A straight, white, physically able, economically secure male
+is less likely to be interrupted when speaking,
+more likely to be called on in class,
+and more likely to get a job interview based on an identical CV
+than someone who is perceived as being outside these categories.
+The unearned advantage may be small in any individual case,
+but compound interest quickly amplifies these differences:
+someone who is called on more often in class is more likely to be remembered by a professor,
+who in turn is therefore more likely to recommend them to a potential employer,
+who is more likely to excuse the poor grades on their transcripts,
+and on and on it goes.
+People who are privileged are often not aware of it
+for the same reason that most fish don't know what water tastes like.
+
+A [target](#g:target-oppression) is someone who suffers from oppression.
+Targets are often called "members of a marginalized group",
+but that phrasing is deliberately passive.
+Targets don't choose to be marginalized:
+those with privilege marginalize them.
+An [ally](#g:ally) is a member of a privileged group
+who is working to understand their own privilege and end oppression.
+For example,
+privilege is being able to walk into a store and have the owner assume you're there to buy things,
+not to steal them.
+Oppression is the stories told about (for example) indigenous people being thieves,
+and the actions people take as a result of them.
+A target is an indigenous person who wants to buy milk,
+and an ally is a white person who pays attention to a lesson like this one (raising their own awareness),
+calls out peers who spread racist stories (a [peer action](#g:peer-action)),
+or asks the shopkeeper whether they should leave too (a [situational action](#g:situational-action)).
+
+Why should you be an ally?
+You could do it out of a sense of fairness
+because you realize that you have benefited from oppression
+even if you haven't taken part (or don't think you have).
+And you should do it because you can:
+taking action to value diversity results in worse performance ratings for minority and female leaders,
+while ethnic majority or male leaders who do this aren't penalized [Hekm2017](#BIB).
+As soon as you acknowledge that (for example) women are called on less often than men,
+or are less likely to get an interview or a publication given identical work,
+you have to acknowledge that white and Asian males are *more* likely to get these benefits than their performance alone deserves.
+
+## How can I be a good ally for members of marginalized groups? {#s:inclusive-how-ally}
+
+So much for the theory:
+what should you actually do?
+A few simple rules will go a long way:
+
+1.  Be short, simple, and firm.
+2.  Don't try to be funny: it almost always backfires, or will later be used against you.
+3.  Play for the audience:
+    you probably won't change the mind of the oppressor you're calling out,
+    but you might change the minds or give heart to people who are observing.
+4.  Pick your battles.
+    You can't challenge everyone, every time,
+    without exhausting yourself and deafening your audience.
+    An occasional sharp retort will be much more effective than constant criticism.
+5.  Don't shame or insult one group when trying to help another.
+    For example,
+    don't call someone stupid when what you really mean is that they're racist or homophobic.
+6.  Change the terms of the debate.
+
+The last rule is best explained by example.
+Suppose someone says,
+"Why should we take diversity into account when hiring?
+Why don't we just hire the best candidate?"
+Your response could be,
+"Because taking diversity into account *is* hiring the best candidate.
+If you can run a mile in four minutes and someone else can do it in 4:15 with a ball and chain on their leg,
+who the better athlete?
+Who will perform better *if the impediment is removed*?
+If you intend to preserve an exclusionary culture in this lab,
+considering how much someone has achieved despite systemic unfairness might not make sense,
+but you're not arguing for that,
+are you?"
+And if someone then says,
+"But it's not fair to take anything other than technical skill into account when hiring for a technical job,"
+you can say,
+"You're right,
+which means that what you're *really* upset about is the thought that
+you might be treated the way targets have been treated their whole lives."
+
+[Captain Awkward][captain-awkward] has useful advice,
+and [Charles' Rules of Argument][charles-rules] are very useful online:
+
+1.  Don't go looking for an argument.
+2.  State your position once, speaking to the audience.
+3.  Wait for absurd replies.
+4.  Reply once more to correct any misunderstandings of your original statement.
+5.  Do not reply again---go do something fun instead.
+
+Finally,
+it's important to recognize that good principles sometimes conflict.
+For example,
+consider this scenario:
+
+> A manager consistently uses male pronouns to refer to software and people of unknown gender.
+> When you tell them it makes you uncomfortable to treat maleness as the norm,
+> they say that male is the default gender in their first language
+> and you should be more considerate of people from other cultures.
+
+On the one hand,
+you want to respect other people's cultures;
+on the other hand,
+you want to be inclusive of women.
+In this case,
+the manager's discomfort about changing pronouns
+matters less than the career harm caused by them being exclusionary,
+but many cases are not this clear cut.
+Like any written rules,
+a Code of Conduct requires constant interpretation;
+like everything else,
+discussion about specific cases becomes easier with practice.
+
+## Summary {#s:inclusive-summary}
+
+FIXME: create concept map for making an inclusive project
+
+## Exercises {#s:inclusive-exercises}
+
+FIXME: exercises for creating an inclusive project.
+
+{% include links.md %}


### PR DESCRIPTION
Addresses #161, #148, #162 

The initial intent from [`rse-goals.md`](https://github.com/merely-useful/merely-useful.github.io/blob/book/rse-goals.md) was for this to be a single section, but I'd like to propose the following split into Project Management and Team Management:

# Project management

## Questions

How can we keep track of current tasks?
How can we figure out what to build next?

## Tracking tasks
  - issue tracking
  - issue tagging as lightweight workflow

## Planning and prioritizing 
  - models: planning vs. agile, 3x3 prioritization
  - tools: roadmaps and milestones (a la GitHub), Open Canvas

# Team management

## Questions

How do we encourage participation of a diverse group?
How do we make collaborative decisions?
How do we manage interpersonal conflict?

## Including everyone
  - allyship: who is your team?
  - readme and contributing guidelines
  - licensing

## Collaborative decision making
  - how to run a meeting
  - project governance

## Managing interpersonal conflict
  - potential types of conflict:
  - sources of conflict
  - strategies for handling difficult project members

Current PR is a dump of previous material and ideas from brainstorming.