### PR TITLE
Starting fix for #294 (failure to load dog licensing data).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ _bookdown_files
 _main.Rmd
 _novice_py
 _novice_r
+data/nyc-dog-licenses.csv
 birds.png
 index.Rmd
 merely-useful.Rmd

--- a/Makefile
+++ b/Makefile
@@ -132,11 +132,13 @@ r-rse-html : _book/r-rse/index.html
 _book/r/index.html : ${R_FILES} ${COMMON_FILES} ${INDEX_HTML}
 	rm -f r.Rmd
 	cp r-index.Rmd index.Rmd
+	gunzip -c data/nyc-dog-licenses.csv.gz > data/nyc-dog-licenses.csv
 	Rscript -e "bookdown::render_book(input='index.Rmd', output_format='bookdown::gitbook', config_file='_r.yml'); warnings()"
 
 _book/py/index.html : ${PY_FILES} ${COMMON_FILES} ${INDEX_HTML}
 	rm -f py.Rmd
 	cp py-index.Rmd index.Rmd
+	gunzip -c data/nyc-dog-licenses.csv.gz > data/nyc-dog-licenses.csv
 	Rscript -e "bookdown::render_book(input='index.Rmd', output_format='bookdown::gitbook', config_file='_py.yml'); warnings()"
 
 _book/py-rse/index.html : ${PY_RSE_FILES} ${COMMON_FILES} ${INDEX_HTML}

--- a/py/data-manipulation.Rmd
+++ b/py/data-manipulation.Rmd
@@ -23,7 +23,7 @@ import pandas as pd # import the pandas package
 
 # where is the file located on your computer?
 # you can use a path relative to the current directory (shown in the example), or the full path (i.e. /home/madeleine/data/file.csv)
-filename = "data/nyc-dog-licensing.csv"
+filename = "data/nyc-dog-licenses.csv"
 
 # the function pd.read_csv() takes a file path as its default input and tries to read in a table of data.
 # here we assign the function's output to a variable called "dog_licenses"


### PR DESCRIPTION
Partial fix for #294:

1.  Uncompress `data/nyc-dog-licenses.csv.gz` as needed.
2.  Modify `.gitignore` to ignore the uncompressed file.
3.  Correct the filepath in `py/data-manipulation.Rmd`.

This still does not produce a working build: we get a complaint about subtracting `datetime` objects with and without timezone information.