### PR TITLE
Temporary fix for #294: only build R and Python RSE volumes automatically.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ py : _book/py/index.html _book/py/rse.pdf
 py-rse : _book/py-rse/index.html _book/py-rse/py-rse.pdf
 
 ##   r-rse      : rebuild RSE R HTML and PDF.
-rse : _book/r-rse/index.html _book/r-rse/r-rse.pdf
+r-rse : _book/r-rse/index.html _book/r-rse/r-rse.pdf
 
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
1.  Rename the `rse` target in `Makefile` to `r-rse` to accurately reflect what it does (it builds the R RSE volume, not both of the RSE volumes).
2.  Modify `.travis.yml` to only build the R and Python RSE volumes for now while we try to figure out the broken `datetime` manipulation described in #295.