### PR TITLE
Add Provenance exercises

### DIFF
--- a/book.bib
+++ b/book.bib
@@ -570,6 +570,19 @@
   note = {Popularized the phrase, "With great power comes great responsibility."}
 }
 
+@article{leonhardt2017,
+    author = {Leonhardt, Aljoscha AND Meier, Matthias AND Serbe, Etienne AND Eichner, Hubert AND Borst, Alexander},
+    journal = {PLOS ONE},
+    publisher = {Public Library of Science},
+    title = {Neural mechanisms underlying sensitivity to reverse-phi motion in the fly},
+    year = {2017},
+    month = {12},
+    volume = {12},
+    url = {https://doi.org/10.1371/journal.pone.0189019},
+    pages = {1-25},
+    number = {12},
+    doi = {10.1371/journal.pone.0189019}
+}
 @book{Lind2008,
   author = {Van Lindberg},
   title = {Intellectual Property and Open Source: A Practical Guide to Protecting Code},
@@ -682,7 +695,7 @@
   journal = {{PLoS ONE}},
   volume = {11},
   number = {1},
-  pages = {e0147073},    
+  pages = {e0147073},
   month = {Jan},
   year = {2016},
   doi = {10.1371/journal.pone.0147073},

--- a/links.md
+++ b/links.md
@@ -35,6 +35,8 @@
 [git-ssh-github]: https://help.github.com/articles/generating-ssh-keys
 [git-ssh-gitlab]: https://about.gitlab.com/2014/03/04/add-ssh-key-screencast/
 [github-gitignore]: https://github.com/github/gitignore
+[github-release]:https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository
+[github-release-link]: https://docs.github.com/en/github/administering-a-repository/linking-to-releases
 [github-zenodo-tutorial]: https://guides.github.com/activities/citable-code/
 [github]: https://github.com
 [gitkraken]: https://www.gitkraken.com/

--- a/py-rse/provenance.Rmd
+++ b/py-rse/provenance.Rmd
@@ -447,6 +447,7 @@ The GitHub repository https://github.com/borstlab/reversephi_paper/ provides the
 2. Where are the data processing steps described? How could you re-create the results included in the manuscript?
 3. How are the scripts and data archived?  I.e. Where can you download the version of the code and data as it was when the manuscript was published?
 
+To get a feel for the different approaches to code provenance, repeat steps 1-3 for... [TODO: List a few more papers.] 
 ### Making permanent links {#provenance-ex-permanent-links}
 
 The link to the UK Home Office's [accessibility guideline posters][ukho-accessibility] might change in future.
@@ -454,8 +455,8 @@ Use the [Wayback Machine][wayback-machine] to find a link that is more likely to
 
 ### Create a citable archive of your Zipf's analysis {#provenance-ex-zenodo}
 
-Follow [the tutorial mentioned][github-zenodo-tutorial] in  Section \@ref(code-provenance-scripts)
-to create a citable archive of the current state of your `zipfs/` project.
+Follow [the tutorial mentioned][github-zenodo-tutorial] in Section \@ref(code-provenance-scripts)
+to create a citable archive of the current state of your `zipf/` project.
 
 ### Publishing your code {#provenance-ex-publish-code}
 

--- a/py-rse/provenance.Rmd
+++ b/py-rse/provenance.Rmd
@@ -439,10 +439,23 @@ then review the spreadsheet file and the coded response file.
 4.  This dataset is clearly in support of an article.
     What information can you find about it, and can you find a link to it?
 
+### Evaluate a project's code provenance {#provenance-ex-eval-code}
+
+The GitHub repository https://github.com/borstlab/reversephi_paper/ provides the code and data for the paper @leonhardt2017.  Browse the repository and answer the following questions:
+
+1. Where is the software environment described? What files would you need to recreate the software environment? 
+2. Where are the data processing steps described? How could you re-create the results included in the manuscript?
+3. How are the scripts and data archived?  I.e. Where can you download the version of the code and data as it was when the manuscript was published?
+
 ### Making permanent links {#provenance-ex-permanent-links}
 
 The link to the UK Home Office's [accessibility guideline posters][ukho-accessibility] might change in future.
 Use the [Wayback Machine][wayback-machine] to find a link that is more likely to be usable in the long run.
+
+### Create a citable archive of your Zipf's analysis {#provenance-ex-zenodo}
+
+Follow [the tutorial mentioned][github-zenodo-tutorial] in  Section \@ref(code-provenance-scripts)
+to create a citable archive of the current state of your `zipfs/` project.
 
 ### Publishing your code {#provenance-ex-publish-code}
 

--- a/py-rse/provenance.Rmd
+++ b/py-rse/provenance.Rmd
@@ -448,15 +448,36 @@ The GitHub repository https://github.com/borstlab/reversephi_paper/ provides the
 3. How are the scripts and data archived?  I.e. Where can you download the version of the code and data as it was when the manuscript was published?
 
 To get a feel for the different approaches to code provenance, repeat steps 1-3 for... [TODO: List a few more papers.] 
+
 ### Making permanent links {#provenance-ex-permanent-links}
 
 The link to the UK Home Office's [accessibility guideline posters][ukho-accessibility] might change in future.
 Use the [Wayback Machine][wayback-machine] to find a link that is more likely to be usable in the long run.
 
-### Create a citable archive of your Zipf's analysis {#provenance-ex-zenodo}
+### Create an archive of your Zipf's analysis {#provenance-ex-release}
 
-Follow [the tutorial mentioned][github-zenodo-tutorial] in Section \@ref(code-provenance-scripts)
-to create a citable archive of the current state of your `zipf/` project.
+A slightly less permanent alternative to having a DOI 
+for your analysis code
+is to provide a link to a GitHub release.  
+
+Follow [the instructions on GitHub][github-release] 
+to create a release
+for the current state of your `zipf/` project.
+
+Once you've created the release, 
+[read about how to link to it][github-release-link].
+What is the URL that allows direct download of the zip archive
+of your release?
+
+> **What about getting a DOI?**
+> 
+> Creating a GitHub release is also a neccessary step
+> to get a DOI through the Zenodo/Github integration 
+> (Section \@ref(code-provenance-scripts)).
+> We are stopping short of getting the DOI here,
+> to avoid many DOIs pointing to the same code,
+> that is associated with different authors (you), 
+> and that isn't associated with a publication
 
 ### Publishing your code {#provenance-ex-publish-code}
 

--- a/py-rse/provenance.Rmd
+++ b/py-rse/provenance.Rmd
@@ -443,7 +443,6 @@ then review the spreadsheet file and the coded response file.
 
 The link to the UK Home Office's [accessibility guideline posters][ukho-accessibility] might change in future.
 Use the [Wayback Machine][wayback-machine] to find a link that is more likely to be usable in the long run.
-The fourth file is normally only found in research projects:
 
 ### Publishing your code {#provenance-ex-publish-code}
 

--- a/py-rse/solutions.Rmd
+++ b/py-rse/solutions.Rmd
@@ -976,9 +976,10 @@ To re-create the `conda` environment you would need the file, `my_environment.ym
 
 <https://web.archive.org/web/20191105173924/https://ukhomeoffice.github.io/accessibility-posters/posters/accessibility-posters.pdf>
 
-### Exercise \@ref(#provenance-ex-zenodo) {-} 
+### Exercise \@ref(#provenance-ex-release) {-} 
 
-You'll know you've completed this exercise when you have a DOI issued by Zenodo that links to a release on your GitHub repository.
+You'll know you've completed this exercise when you have a URL that
+points to ZIP archive for a specific release of your repository on GitHub, e.g. `https://github.com/DamienIrving/zipf/archive/KhanVirtanen2020.zip`
 
 ## Chapter \@ref(packaging)
 

--- a/py-rse/solutions.Rmd
+++ b/py-rse/solutions.Rmd
@@ -964,11 +964,11 @@ but that difference is not explained anywhere.
 
 ### Exercise \@ref(provenance-ex-eval-code) {-}
 
-1. The software requirements are documented in `README.md`. In addition, to the tools used in the `zipfs/` project (Python, Make and Git), the project also requires ImageMagick.  No information on installing ImageMagick or a required version of ImageMagick is provided.
+1. The software requirements are documented in `README.md`. In addition, to the tools used in the `zipf/` project (Python, Make and Git), the project also requires ImageMagick.  No information on installing ImageMagick or a required version of ImageMagick is provided.
 
 To re-create the `conda` environment you would need the file, `my_environment.yml`.  Instructions for creating and using the environment are provided in `README.md`.
 
-2.  Like `zipfs` the data processing and analysis steps are documented in a `Makefile`.  The `README` includes instructions for re-creating the results using `make all`.
+2.  Like `zipf` the data processing and analysis steps are documented in a `Makefile`.  The `README` includes instructions for re-creating the results using `make all`.
 
 3.  There doesn't seem to be a DOI for the archived code and data, but the GitHub repo does have a release `v1.0` with the description "Published manuscript (1.0)".  A zip file of this release could be downloaded with the link https://github.com/borstlab/reversephi_paper/archive/v1.0.zip.
 

--- a/py-rse/solutions.Rmd
+++ b/py-rse/solutions.Rmd
@@ -962,9 +962,23 @@ while the other two say 2010-2013.
 We might come to a conclusion that this extra year is where the extra 9 interviews come in,
 but that difference is not explained anywhere.
 
+### Exercise \@ref(provenance-ex-eval-code) {-}
+
+1. The software requirements are documented in `README.md`. In addition, to the tools used in the `zipfs/` project (Python, Make and Git), the project also requires ImageMagick.  No information on installing ImageMagick or a required version of ImageMagick is provided.
+
+To re-create the `conda` environment you would need the file, `my_environment.yml`.  Instructions for creating and using the environment are provided in `README.md`.
+
+2.  Like `zipfs` the data processing and analysis steps are documented in a `Makefile`.  The `README` includes instructions for re-creating the results using `make all`.
+
+3.  There doesn't seem to be a DOI for the archived code and data, but the GitHub repo does have a release `v1.0` with the description "Published manuscript (1.0)".  A zip file of this release could be downloaded with the link https://github.com/borstlab/reversephi_paper/archive/v1.0.zip.
+
 ### Exercise \@ref(provenance-ex-permanent-links) {-}
 
 <https://web.archive.org/web/20191105173924/https://ukhomeoffice.github.io/accessibility-posters/posters/accessibility-posters.pdf>
+
+### Exercise \@ref(#provenance-ex-zenodo) {-} 
+
+You'll know you've completed this exercise when you have a DOI issued by Zenodo that links to a release on your GitHub repository.
 
 ## Chapter \@ref(packaging)
 


### PR DESCRIPTION
Added two exercises:

1. Low hanging exercise to follow the tutorial mentioned about GitHub and Zenodo integration

2. Exercise to explore a project's approach to code provenance.  I have no attachment to the project used in the exercise.  If anyone has a better example to point to, I'd be happy to incorporate.